### PR TITLE
increase timeout in linenoiseProbe 

### DIFF
--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1045,7 +1045,7 @@ int linenoiseProbe(void) {
     flushWrite();
 
     /* Try to read response */
-    int timeout_ms = 200;
+    int timeout_ms = 2000;
     const int retry_ms = 10;
     size_t read_bytes = 0;
     while (timeout_ms > 0 && read_bytes < 4) { // response is ESC[0n or ESC[3n


### PR DESCRIPTION
increase timeout in linenoiseProbe so that line editing features work in serial over network connections (e.g. RFC2217)