### PR TITLE
i2c.c: Fix issue https://github.com/espressif/esp-idf/issues/4999

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -1452,11 +1452,13 @@ esp_err_t i2c_master_cmd_begin(i2c_port_t i2c_num, i2c_cmd_handle_t cmd_handle, 
     i2c_cmd_evt_t evt;
     while (1) {
         TickType_t wait_time = xTaskGetTickCount();
+        // Fix https://github.com/espressif/esp-idf/issues/4999
         if (wait_time - ticks_start > ticks_to_wait) { // out of time
-            wait_time = I2C_CMD_ALIVE_INTERVAL_TICK;
+            wait_time = 1; // already spent too much time here, only wait a little more
         } else {
             wait_time = ticks_to_wait - (wait_time - ticks_start);
-            if (wait_time < I2C_CMD_ALIVE_INTERVAL_TICK) {
+            // if remaining time is more than 1s, just wait 1s and check the the status then
+            if (wait_time > I2C_CMD_ALIVE_INTERVAL_TICK) {
                 wait_time = I2C_CMD_ALIVE_INTERVAL_TICK;
             }
         }


### PR DESCRIPTION
Fix problem that i2c_master_cmd_begin() waits longer (at least 1 second) than specified in ticks_to_wait, in case the bus is stuck.