### PR TITLE
linenoise: increase timeout in linenoiseProbe to handle slow consoles…

### DIFF
--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1045,7 +1045,7 @@ int linenoiseProbe(void) {
     flushWrite();
 
     /* Try to read response */
-    int timeout_ms = 200;
+    int timeout_ms = 2000;
     const int retry_ms = 10;
     size_t read_bytes = 0;
     while (timeout_ms > 0 && read_bytes < 4) { // response is ESC[0n or ESC[3n


### PR DESCRIPTION
… (e.g. via network)